### PR TITLE
mobile d&d

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,18 +1,21 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
+
+<head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap" rel="stylesheet">
     <title>quantum</title>
-  </head>
-  <body>
+</head>
+
+<body>
     <noscript>
       <strong>We're sorry but quantum doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->
-  </body>
+</body>
+
 </html>

--- a/src/components/Board/AppCell.vue
+++ b/src/components/Board/AppCell.vue
@@ -3,8 +3,8 @@
     ref="cellRef"
     :style="positionStyle"
     :class="computedCellClass"
-    @mousedown="handleCellClick"
-    @mouseup="handleCellUp"
+    @mousedown="deviceTargetDown"
+    @mouseup="deviceTargetUp"
   >
     <rect
       :width="tileSize"
@@ -101,6 +101,40 @@ export default class AppCell extends Mixins(getPosition) {
    *  2. determines if the updateCell event should be emitted
    *  @returns void
    */
+
+  deviceTargetDown() {
+    return window.innerWidth <= 1024 ? this.handleCellTouch() : this.handleCellClick();
+  }
+
+  deviceTargetUp() {
+    return window.innerWidth >= 1024 && this.handleCellUp();
+  }
+
+  handleCellTouch(): void {
+    if (
+      this.cell.frozen ||
+      (!this.cellSelected && this.cell.isFromToolbox && !this.available) ||
+      (this.cellSelected && this.isActiveCell && this.cell.isFromToolbox)
+    ) {
+      this.mutationResetActiveCell();
+    } else {
+      if (!this.cellSelected) {
+        if (this.cell.tool && (this.cell.isFromGrid || this.cell.isFromToolbox)) {
+          this.border = 'white';
+          this.mutationSetActiveCell(this.cell);
+          return;
+        }
+        this.border = '';
+        this.mutationResetActiveCell();
+        return;
+      }
+      if (this.isActiveCell && this.cell.isFromGrid) {
+        this.cell.rotate();
+      }
+      this.$emit('updateCell', this.cell);
+      this.mutationResetActiveCell();
+    }
+  }
 
   mouseMove(e: any): void {
     const hoverCell = document.querySelector('.hoverCell') as HTMLElement;


### PR DESCRIPTION
Hey, I tested drag and drop on mobile on several devices and it's not working well. When user drag element screen scrolling along with touch. I try to omit this behavior, but it's just a mobile browser thing. So on mobile i set to click&click, it's much better experience. The border between dragging and clicking is 1024px. 