### PR TITLE
Transition matrix new design

### DIFF
--- a/src/components/EncyclopediaPage/EncyclopediaMatrix.vue
+++ b/src/components/EncyclopediaPage/EncyclopediaMatrix.vue
@@ -141,15 +141,29 @@ import { IMatrixElement } from '../../engine/interfaces'
 @Component
 export default class EncyclopediaOperatorViewer extends Vue {
   @Prop({ default: () => 40 }) private size!: number
-  @Prop({ default: () => [] }) private labelsIn!: string[]
-  @Prop({ default: () => [] }) private labelsOut!: string[]
+  @Prop({ default: () => [] }) private coordNamesIn!: string[][]
+  @Prop({ default: () => [] }) private coordNamesOut!: string[][]
   @Prop({ default: () => [] }) private dimensionNames!: string[]
   @Prop({ default: () => [] }) private matrixElements!: IMatrixElement[]
-  // TODO: reduce width and height
 
   selectedColumn = -1
 
-  // lablesIn string[][] ?
+  /**
+   * @todo Flattening should be in QT.Dimension.
+   * Here I do only for 2 dims.
+   */
+  get labelsIn(): string[] {
+    const [names1, names2] = this.coordNamesIn
+    return names1.flatMap((coord1) => names2.map((coord2) => `${coord1}${coord2}`))
+  }
+
+  /**
+   * @see {@link labelsIn}
+   */
+  get labelsOut(): string[] {
+    const [names1, names2] = this.coordNamesOut
+    return names1.flatMap((coord1) => names2.map((coord2) => `${coord1}${coord2}`))
+  }
 
   get columnSize(): number {
     return this.size * this.labelsIn.length

--- a/src/components/EncyclopediaPage/EncyclopediaMatrix.vue
+++ b/src/components/EncyclopediaPage/EncyclopediaMatrix.vue
@@ -4,23 +4,14 @@
       <text class="label" :x="rowSize / 2" :y="scale(-0.25)">
         Input
       </text>
-      <rect
-        v-for="(label, i) in labelsIn"
-        :key="`menu-tile-out-1-${i}`"
-        class="menu-tile"
-        :x="scale(i)"
-        :y="scale(0)"
-        :width="size"
-        :height="size"
-      />
       <text
-        v-for="(label, i) in labelsIn"
-        :key="`label-in-1-${label}`"
+        v-for="(coord, i) in coordNamesIn[0]"
+        :key="`label-in-1-${coord}`"
         class="label-in"
-        :x="scale(i + 0.5)"
+        :x="scale(coordNamesIn[1].length * (i + 0.5))"
         :y="scale(0.5)"
       >
-        {{ label[0] }}
+        {{ coord }}
       </text>
       <rect
         v-for="(label, i) in labelsIn"
@@ -40,31 +31,31 @@
       >
         {{ label[1] }}
       </text>
+      <rect
+        v-for="(coord, i) in coordNamesIn[0]"
+        :key="`menu-tile-out-1-${i}`"
+        class="menu-tile-head"
+        :x="scale(coordNamesIn[1].length * i)"
+        :y="scale(0)"
+        :width="coordNamesIn[1].length * size"
+        :height="2 * size"
+      />
     </g>
     <g class="labels-out" :transform="`translate(${1 * size}, ${3 * size})`">
       <text class="label" :transform="`translate(${scale(-0.25)},${columnSize / 2}) rotate(270)`">
         Output
       </text>
-      <rect
-        v-for="(label, j) in labelsIn"
-        :key="`menu-tile-in-1-${j}`"
-        class="menu-tile"
-        :x="scale(0)"
-        :y="scale(j)"
-        :width="size"
-        :height="size"
-      />
       <text
-        v-for="(label, j) in labelsIn"
-        :key="`label-out-1-${label}`"
+        v-for="(coord, j) in coordNamesOut[0]"
+        :key="`label-out-1-${coord}`"
         class="label-out"
         :x="scale(0.5)"
-        :y="scale(j + 0.5)"
+        :y="scale(coordNamesOut[1].length * (j + 0.5))"
       >
-        {{ label[0] }}
+        {{ coord }}
       </text>
       <rect
-        v-for="(label, j) in labelsIn"
+        v-for="(label, j) in labelsOut"
         :key="`menu-tile-in-2-${j}`"
         class="menu-tile"
         :x="scale(1)"
@@ -73,7 +64,7 @@
         :height="size"
       />
       <text
-        v-for="(label, j) in labelsIn"
+        v-for="(label, j) in labelsOut"
         :key="`label-out-2-${label}`"
         class="label-out"
         :x="scale(1.5)"
@@ -81,6 +72,15 @@
       >
         {{ label[1] }}
       </text>
+      <rect
+        v-for="(coord, j) in coordNamesOut[0]"
+        :key="`menu-tile-in-1-${j}`"
+        class="menu-tile-head"
+        :x="scale(0)"
+        :y="scale(coordNamesOut[1].length * j)"
+        :width="2 * size"
+        :height="coordNamesOut[1].length * size"
+      />
       <g class="dimension-labels" @click="swapDimensions()">
         <text
           v-for="(dimensionName, j) in dimensionNames"
@@ -189,6 +189,9 @@ export default class EncyclopediaOperatorViewer extends Vue {
     return 0.5 * this.size * Math.sqrt(re ** 2 + im ** 2)
   }
 
+  /**
+   * @todo Show directly on the legend.
+   */
   tileMouseOver(tile: IMatrixElement): void {
     this.selectedColumn = tile.i
     this.$emit('columnMouseover', tile.i)
@@ -257,7 +260,8 @@ export default class EncyclopediaOperatorViewer extends Vue {
   stroke-width: 0.5px;
 }
 
-.entry-boarder {
+.entry-boarder,
+.menu-tile-head {
   fill: none;
   stroke: #5c00d3;
   stroke-width: 1.5px;

--- a/src/components/EncyclopediaPage/EncyclopediaMatrix.vue
+++ b/src/components/EncyclopediaPage/EncyclopediaMatrix.vue
@@ -51,6 +51,7 @@
         v-for="(coord, j) in coordNamesOut[0]"
         :key="`label-out-1-${coord}`"
         class="label-out"
+        :class="{ 'label-selected': selectedOutputLabels.ones.indexOf(coord) >= 0 }"
         :x="scale(0.5)"
         :y="scale(coordNamesOut[1].length * (j + 0.5))"
       >
@@ -69,6 +70,7 @@
         v-for="(label, j) in labelsOut"
         :key="`label-out-2-${label}`"
         class="label-out"
+        :class="{ 'label-selected': selectedOutputLabels.indices.indexOf(j) >= 0 }"
         :x="scale(1.5)"
         :y="scale(j + 0.5)"
       >
@@ -225,6 +227,13 @@ export default class EncyclopediaOperatorViewer extends Vue {
     }
   }
 
+  get selectedOutputLabels(): { ones: string[]; indices: number[] } {
+    const js = this.matrixElements.filter((d) => d.i === this.selectedEntry.i)
+    const indices = js.map((d) => d.j)
+    const ones = indices.map((j) => this.labelsOut[j][0])
+    return { ones, indices }
+  }
+
   /**
    * @todo Flattening should be in QT.Dimension.
    * Here I do only for 2 dims.
@@ -301,7 +310,7 @@ export default class EncyclopediaOperatorViewer extends Vue {
 }
 
 .label-in.label-selected,
-.label-out.label-in.label-selected {
+.label-out.label-selected {
   fill: white;
 }
 

--- a/src/components/EncyclopediaPage/EncyclopediaMatrix.vue
+++ b/src/components/EncyclopediaPage/EncyclopediaMatrix.vue
@@ -1,39 +1,111 @@
 <template>
   <svg class="operator-viewer" :width="width" :height="height">
-    <g class="labels-in" :transform="`translate(${1.5 * margin}, ${0.5 * margin})`">
+    <g class="labels-in" :transform="`translate(${2 * size}, ${0})`">
+      <rect
+        v-for="(label, i) in labelsIn"
+        :key="`menu-tile-out-1-${i}`"
+        class="menu-tile"
+        :x="scale(i)"
+        :y="scale(0)"
+        :width="size"
+        :height="size"
+      />
       <text
         v-for="(label, i) in labelsIn"
-        :key="`label-in-${label}`"
+        :key="`label-in-1-${label}`"
         class="label-in"
-        :x="scale(i)"
-        :y="0"
+        :x="scale(i + 0.5)"
+        :y="scale(0.5)"
       >
-        ⟨{{ label }}|
+        {{ label[0] }}
       </text>
-    </g>
-    <g class="labels-out" :transform="`translate(${0.5 * margin}, ${1.5 * margin})`">
-      <text
-        v-for="(label, i) in labelsOut"
-        :key="`label-out-${label}`"
-        class="label-out"
-        :x="0"
-        :y="scale(i)"
-        dy="0.5em"
-      >
-        |{{ label }}⟩
-      </text>
-    </g>
-    <g :transform="`translate(${margin}, ${margin})`">
       <rect
-        v-for="(d, i) in matrixElements"
-        :key="i"
-        class="tile"
+        v-for="(label, i) in labelsIn"
+        :key="`menu-tile-out-2-${i}`"
+        class="menu-tile"
+        :x="scale(i)"
+        :y="scale(1)"
+        :width="size"
+        :height="size"
+      />
+      <text
+        v-for="(label, i) in labelsIn"
+        :key="`label-in-2-${label}`"
+        class="label-in"
+        :x="scale(i + 0.5)"
+        :y="scale(1.5)"
+      >
+        {{ label[1] }}
+      </text>
+    </g>
+    <g class="labels-out" :transform="`translate(${0}, ${2 * size})`">
+      <rect
+        v-for="(label, j) in labelsIn"
+        :key="`menu-tile-in-1-${j}`"
+        class="menu-tile"
+        :x="scale(0)"
+        :y="scale(j)"
+        :width="size"
+        :height="size"
+      />
+      <text
+        v-for="(label, j) in labelsIn"
+        :key="`label-out-1-${label}`"
+        class="label-out"
+        :x="scale(0.5)"
+        :y="scale(j + 0.5)"
+      >
+        {{ label[0] }}
+      </text>
+      <rect
+        v-for="(label, j) in labelsIn"
+        :key="`menu-tile-in-2-${j}`"
+        class="menu-tile"
+        :x="scale(1)"
+        :y="scale(j)"
+        :width="size"
+        :height="size"
+      />
+      <text
+        v-for="(label, j) in labelsIn"
+        :key="`label-out-2-${label}`"
+        class="label-out"
+        :x="scale(1.5)"
+        :y="scale(j + 0.5)"
+      >
+        {{ label[1] }}
+      </text>
+    </g>
+
+    <g :transform="`translate(${2 * size}, ${2 * size})`">
+      <rect
+        v-for="d in allTileLocations"
+        :key="`entry-tile-${d.i}-${d.j}`"
+        class="entry-tile"
         :x="scale(d.i)"
         :y="scale(d.j)"
         :width="size"
         :height="size"
+        @mouseover="tileMouseOver(d)"
+      />
+      <rect class="entry-boarder" :x="0" :y="0" :width="columnSize" :height="rowSize" />
+      <circle
+        v-for="d in matrixElements"
+        :key="`circle-${d.i}-${d.j}`"
+        class="tile-value"
+        :cx="scale(d.i + 0.5)"
+        :cy="scale(d.j + 0.5)"
+        :r="r(d.re, d.im)"
         :style="{ fill: generateColor(d.re, d.im) }"
         @mouseover="tileMouseOver(d)"
+      />
+      <rect
+        v-if="selectedColumn > -1"
+        class="selected-column"
+        :x="scale(selectedColumn)"
+        :y="0"
+        :width="size"
+        :height="columnSize"
       />
     </g>
   </svg>
@@ -52,9 +124,26 @@ export default class EncyclopediaOperatorViewer extends Vue {
   @Prop({ default: () => 600 }) private height!: number
   @Prop({ default: () => 40 }) private size!: number
   @Prop({ default: () => 40 }) private margin!: number
-  @Prop({ default: () => [] }) private labelsIn!: number[]
-  @Prop({ default: () => [] }) private labelsOut!: number[]
+  @Prop({ default: () => [] }) private labelsIn!: string[]
+  @Prop({ default: () => [] }) private labelsOut!: string[]
   @Prop({ default: () => [] }) private matrixElements!: IMatrixElement[]
+  // TODO: reduce width and height
+
+  selectedColumn = -1
+
+  // lablesIn string[][] ?
+
+  get columnSize(): number {
+    return this.size * this.labelsIn.length
+  }
+
+  get rowSize(): number {
+    return this.size * this.labelsOut.length
+  }
+
+  get allTileLocations(): { i: number; j: number }[] {
+    return this.labelsOut.flatMap((_, j) => this.labelsIn.map((_, i) => ({ i, j })))
+  }
 
   scale(i: number): number {
     return i * this.size
@@ -64,7 +153,12 @@ export default class EncyclopediaOperatorViewer extends Vue {
     return colorComplex(re, im)
   }
 
+  r(re: number, im: number): number {
+    return 0.5 * this.size * Math.sqrt(re ** 2 + im ** 2)
+  }
+
   tileMouseOver(tile: IMatrixElement): void {
+    this.selectedColumn = tile.i
     this.$emit('columnMouseover', tile.i)
   }
 }
@@ -78,12 +172,32 @@ export default class EncyclopediaOperatorViewer extends Vue {
 .label-in,
 .label-out {
   font-size: 16px;
-  text-align: center;
+  dominant-baseline: central;
   text-anchor: middle;
   fill: white;
+  cursor: pointer;
 }
 
-.tile {
+.selected-column {
+  fill: none;
+  stroke: #ffffff;
+  stroke-width: 1.5px;
+}
+
+.entry-tile,
+.menu-tile {
+  fill: #2e006a; // to Klem: which color should we use?
+  stroke: #5c00d3;
+  stroke-width: 0.5px;
+}
+
+.entry-boarder {
+  fill: none;
+  stroke: #5c00d3;
+  stroke-width: 1.5px;
+}
+
+.tile-value {
   cursor: pointer;
 }
 </style>

--- a/src/components/EncyclopediaPage/EncyclopediaMatrix.vue
+++ b/src/components/EncyclopediaPage/EncyclopediaMatrix.vue
@@ -1,6 +1,9 @@
 <template>
-  <svg class="operator-viewer" :width="width" :height="height">
-    <g class="labels-in" :transform="`translate(${2 * size}, ${0})`">
+  <svg class="operator-viewer" :width="columnSize + 3.5 * size" :height="rowSize + 6.5 * size">
+    <g class="labels-in" :transform="`translate(${3 * size}, ${1 * size})`">
+      <text class="label" :x="rowSize / 2" :y="scale(-0.25)">
+        Input
+      </text>
       <rect
         v-for="(label, i) in labelsIn"
         :key="`menu-tile-out-1-${i}`"
@@ -38,7 +41,10 @@
         {{ label[1] }}
       </text>
     </g>
-    <g class="labels-out" :transform="`translate(${0}, ${2 * size})`">
+    <g class="labels-out" :transform="`translate(${1 * size}, ${3 * size})`">
+      <text class="label" :transform="`translate(${scale(-0.25)},${columnSize / 2}) rotate(270)`">
+        Output
+      </text>
       <rect
         v-for="(label, j) in labelsIn"
         :key="`menu-tile-in-1-${j}`"
@@ -75,9 +81,25 @@
       >
         {{ label[1] }}
       </text>
+      <g class="dimension-labels" @click="swapDimensions()">
+        <text
+          v-for="(dimensionName, j) in dimensionNames"
+          :key="`label-${dimensionName}`"
+          :transform="`translate(${scale(j + 0.5)},${columnSize + scale(0.25)}) rotate(270)`"
+          class="dimension-label"
+        >
+          {{ dimensionName }}
+        </text>
+        <text
+          :transform="`translate(${scale(1)},${columnSize + scale(1.25)})`"
+          class="dimension-swap"
+        >
+          ⇄
+        </text>
+      </g>
     </g>
 
-    <g :transform="`translate(${2 * size}, ${2 * size})`">
+    <g :transform="`translate(${3 * size}, ${3 * size})`">
       <rect
         v-for="d in allTileLocations"
         :key="`entry-tile-${d.i}-${d.j}`"
@@ -112,20 +134,16 @@
 </template>
 
 <script lang="ts">
-// TODO: Allow to hover an empty column to see results
-// FIXME: Changing will reset the chosen cartesian/polar/color-disk (option menu?)
 import { Component, Prop, Vue } from 'vue-property-decorator'
 import { colorComplex } from '@/engine/Helpers'
 import { IMatrixElement } from '../../engine/interfaces'
 
 @Component
 export default class EncyclopediaOperatorViewer extends Vue {
-  @Prop({ default: () => 800 }) private width!: number
-  @Prop({ default: () => 600 }) private height!: number
   @Prop({ default: () => 40 }) private size!: number
-  @Prop({ default: () => 40 }) private margin!: number
   @Prop({ default: () => [] }) private labelsIn!: string[]
   @Prop({ default: () => [] }) private labelsOut!: string[]
+  @Prop({ default: () => [] }) private dimensionNames!: string[]
   @Prop({ default: () => [] }) private matrixElements!: IMatrixElement[]
   // TODO: reduce width and height
 
@@ -161,6 +179,14 @@ export default class EncyclopediaOperatorViewer extends Vue {
     this.selectedColumn = tile.i
     this.$emit('columnMouseover', tile.i)
   }
+
+  /**
+   * @todo Make all dimension changes within this component.
+   * (After using Operator rather than passed parameteres.)
+   */
+  swapDimensions(): void {
+    this.$emit('swapDimensions')
+  }
 }
 </script>
 
@@ -175,7 +201,33 @@ export default class EncyclopediaOperatorViewer extends Vue {
   dominant-baseline: central;
   text-anchor: middle;
   fill: white;
+  cursor: default;
+}
+
+.dimension-label {
+  font-size: 12px;
+  text-anchor: end;
+  dominant-baseline: central;
+  fill: white;
   cursor: pointer;
+  text-transform: uppercase;
+}
+
+.dimension-swap {
+  font-size: 12px;
+  text-anchor: middle;
+  dominant-baseline: central;
+  fill: white;
+  cursor: pointer;
+  text-transform: uppercase;
+}
+
+.label {
+  font-size: 12px;
+  text-anchor: middle;
+  fill: white;
+  cursor: default;
+  text-transform: uppercase;
 }
 
 .selected-column {

--- a/src/components/EncyclopediaPage/EncyclopediaMatrix.vue
+++ b/src/components/EncyclopediaPage/EncyclopediaMatrix.vue
@@ -8,6 +8,7 @@
         v-for="(coord, i) in coordNamesIn[0]"
         :key="`label-in-1-${coord}`"
         class="label-in"
+        :class="{ 'label-selected': coord === selectedInLabelOne }"
         :x="scale(coordNamesIn[1].length * (i + 0.5))"
         :y="scale(0.5)"
       >
@@ -26,6 +27,7 @@
         v-for="(label, i) in labelsIn"
         :key="`label-in-2-${label}`"
         class="label-in"
+        :class="{ 'label-selected': i === selectedEntry.i }"
         :x="scale(i + 0.5)"
         :y="scale(1.5)"
       >
@@ -215,6 +217,14 @@ export default class EncyclopediaOperatorViewer extends Vue {
     return phi / (2 * Math.PI)
   }
 
+  get selectedInLabelOne(): string {
+    if (this.selectedEntry.i < 0) {
+      return ''
+    } else {
+      return this.labelsIn[this.selectedEntry.i][0]
+    }
+  }
+
   /**
    * @todo Flattening should be in QT.Dimension.
    * Here I do only for 2 dims.
@@ -285,8 +295,14 @@ export default class EncyclopediaOperatorViewer extends Vue {
   font-size: 16px;
   dominant-baseline: central;
   text-anchor: middle;
-  fill: white;
+  fill: #5c00d3;
   cursor: default;
+  font-weight: 900;
+}
+
+.label-in.label-selected,
+.label-out.label-in.label-selected {
+  fill: white;
 }
 
 .dimension-label {

--- a/src/components/EncyclopediaPage/EncyclopediaMatrix.vue
+++ b/src/components/EncyclopediaPage/EncyclopediaMatrix.vue
@@ -289,6 +289,7 @@ export default class EncyclopediaOperatorViewer extends Vue {
    * (After using Operator rather than passed parameteres.)
    */
   swapDimensions(): void {
+    this.selectedColumn = -1 // later we reassign
     this.$emit('swapDimensions')
   }
 }

--- a/src/components/EncyclopediaPage/EncyclopediaTransition.vue
+++ b/src/components/EncyclopediaPage/EncyclopediaTransition.vue
@@ -5,12 +5,11 @@
       <encyclopedia-matrix
         :labels-in="basis"
         :labels-out="basis"
+        :dimension-names="dimensionNames"
         :matrix-elements="matrixElements"
-        :height="320"
-        :width="320"
         :size="30"
-        :margin="70"
         @columnMouseover="updateIndicators($event)"
+        @swapDimensions="dirPolOrder = !dirPolOrder"
       />
       <div class="eboard">
         <encyclopedia-board
@@ -23,13 +22,6 @@
           :exact-steps="true"
           @updateRotation="updateRotation"
         />
-      </div>
-      <div>
-        <span>Select dimension order:</span>
-        <select v-model="dirPolOrder">
-          <option :value="true">dir pol</option>
-          <option :value="false">pol dir</option>
-        </select>
       </div>
     </div>
   </div>
@@ -152,6 +144,13 @@ export default class EncyclopediaMatrixBoard extends Vue {
       return ['⇢H', '⇢V', '⇡H', '⇡V', '⇠H', '⇠V', '⇣H', '⇣V']
     }
     return ['H⇢', 'H⇡', 'H⇠', 'H⇣', 'V⇢', 'V⇡', 'V⇠', 'V⇣']
+  }
+
+  /**
+   * Get the basis direction and polarization strings
+   */
+  get dimensionNames(): string[] {
+    return this.dirPolOrder ? ['direction', 'polarization'] : ['polarization', 'direction']
   }
 
   /**

--- a/src/components/EncyclopediaPage/EncyclopediaTransition.vue
+++ b/src/components/EncyclopediaPage/EncyclopediaTransition.vue
@@ -6,10 +6,10 @@
         :labels-in="basis"
         :labels-out="basis"
         :matrix-elements="matrixElements"
-        :height="300"
-        :width="300"
+        :height="320"
+        :width="320"
         :size="30"
-        :margin="20"
+        :margin="70"
         @columnMouseover="updateIndicators($event)"
       />
       <div class="eboard">
@@ -149,9 +149,9 @@ export default class EncyclopediaMatrixBoard extends Vue {
    */
   get basis(): string[] {
     if (this.dirPolOrder) {
-      return ['⇢↔', '⇢↕', '⇡↔', '⇡↕', '⇠↔', '⇠↕', '⇣↔', '⇣↕']
+      return ['⇢H', '⇢V', '⇡H', '⇡V', '⇠H', '⇠V', '⇣H', '⇣V']
     }
-    return ['↔⇢', '↔⇡', '↔⇠', '↔⇣', '↕⇢', '↕⇡', '↕⇠', '↕⇣']
+    return ['H⇢', 'H⇡', 'H⇠', 'H⇣', 'V⇢', 'V⇡', 'V⇠', 'V⇣']
   }
 
   /**

--- a/src/components/EncyclopediaPage/EncyclopediaTransition.vue
+++ b/src/components/EncyclopediaPage/EncyclopediaTransition.vue
@@ -3,8 +3,8 @@
     <div>
       <h2>{{ elementName }} at {{ rotation }}°</h2>
       <encyclopedia-matrix
-        :labels-in="basis"
-        :labels-out="basis"
+        :coord-names-in="coordNames"
+        :coord-names-out="coordNames"
         :dimension-names="dimensionNames"
         :matrix-elements="matrixElements"
         :size="30"
@@ -139,11 +139,10 @@ export default class EncyclopediaMatrixBoard extends Vue {
   /**
    * Get the basis direction and polarization strings
    */
-  get basis(): string[] {
-    if (this.dirPolOrder) {
-      return ['⇢H', '⇢V', '⇡H', '⇡V', '⇠H', '⇠V', '⇣H', '⇣V']
-    }
-    return ['H⇢', 'H⇡', 'H⇠', 'H⇣', 'V⇢', 'V⇡', 'V⇠', 'V⇣']
+  get coordNames(): string[][] {
+    const coordsDir = ['⇢', '⇡', '⇠', '⇣']
+    const coordsPol = ['H', 'V']
+    return this.dirPolOrder ? [coordsDir, coordsPol] : [coordsPol, coordsDir]
   }
 
   /**


### PR DESCRIPTION
@KlemKlem's design:

![TransitionsMatrix](https://user-images.githubusercontent.com/1001610/70399207-3ba37600-1a22-11ea-89bb-2ec67177c204.png)

Current state (after the first commit):

![Screenshot 2019-12-09 01 17 37](https://user-images.githubusercontent.com/1001610/70399214-4a8a2880-1a22-11ea-8ba6-0e8778844ae9.png)

I still need to add a few bits, so please don't merge it now.

Though, I think that legend (for direction and polarization) has to be somewhat inside the matrix, not outside. Also, it may be nice to have a similar thing (i.e. inside or near, not separately) with:

* dir and pol order
* polarization basis



